### PR TITLE
new options for sanitazer

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -94,6 +94,24 @@
                 </section>
 
                 <section class="content-options-section">
+                    Always show arctiles with rating more than
+                    <form class="content-options-form" autocomplete="off">
+                        <div>
+                            <select id="always-rate">
+					<option value="1000000">[no rate option]</option>
+					<option value="0">0</option>
+					<option value="5">+5</option>
+					<option value="10">+10</option>
+					<option value="15">+15</option>
+					<option value="20">+20</option>
+					<option value="25">+25</option>
+					<option value="50">+50</option>
+				</select>
+                        </div>
+                    </form>
+                </section>
+
+                <section class="content-options-section">
                     User interface options
                     <form class="content-options-form" autocomplete="off">
                         <div>
@@ -101,6 +119,53 @@
                             <label for="quick-actions-toggler" title="Enables hide icon on the site"
                                 >Show quick actions</label
                             >
+                        </div>
+                    </form>
+                </section>
+
+                <section class="content-options-section">
+                    Custom JavaScript
+			<button class="btn " id="save-custom-javascript">
+                                <svg
+                                    width="20px"
+                                    height="20px"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-width="2px"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                >
+                                    <use xlink:href="./asset/sprites.svg#save" />
+                                </svg>
+                            </button>
+
+                    <form class="content-options-form" autocomplete="off">
+                        <div>
+				<textarea id="custom-javascript"></textarea>
+                        </div>
+                    </form>
+                </section>
+
+                <section class="content-options-section">
+                    Custom CSS 
+
+			<button class="btn " id="save-custom-css">
+                                <svg
+                                    width="20px"
+                                    height="20px"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-width="2px"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                >
+                                    <use xlink:href="./asset/sprites.svg#save" />
+                                </svg>
+                            </button>
+
+                    <form class="content-options-form" autocomplete="off">
+                        <div>
+				<textarea id="custom-css"></textarea>
                         </div>
                     </form>
                 </section>

--- a/src/options.js
+++ b/src/options.js
@@ -52,6 +52,21 @@ import { DnD } from './dragAndDrop.js';
         $bans.innerHTML = banList;
     }
 
+
+    /**
+     * @param {Storage} store
+     */
+    function initCustom(store, settings) {
+	document.querySelector('#custom-javascript').value = settings.js ?? '';
+	document.querySelector('#custom-css').value = settings.css ?? '';
+
+        document.querySelector('#save-custom-javascript').addEventListener('click', (e) => store.saveCustomJavaScript(document.querySelector('#custom-javascript').value));
+        document.querySelector('#save-custom-css').addEventListener('click', (e) => store.saveCustomCss(document.querySelector('#custom-css').value));
+
+	document.querySelector('#always-rate').value = settings.rate ?? 1000000;
+        document.querySelector('#always-rate').addEventListener('change', (e) => store.saveAlwaysRate(document.querySelector('#always-rate').value));
+    }
+
     /**
      * @param {Storage} store
      */
@@ -144,6 +159,7 @@ import { DnD } from './dragAndDrop.js';
     initDnD(storage);
     initQuickActions(storage);
     initSaveConfigBtn(storage);
+    initCustom(storage, settings);
 
     updateBanList(settings.banned);
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -78,6 +78,36 @@ export class Storage {
         return this._saveSettings(settings);
     }
 
+     /**
+     * Update and save rate for articles 
+     * @param {number} value of the rate
+     */
+    async saveAlwaysRate(rate) {
+        const settings = await this.loadSettings();
+        settings.rate = rate;
+        return this._saveSettings(settings);
+    }
+
+    /**
+     * Update and save custom javascript
+     * @param {string} js is text of custom javascript
+     */
+    async saveCustomJavaScript(js) {
+        const settings = await this.loadSettings();
+        settings.js = js;
+        return this._saveSettings(settings);
+    }
+
+    /**
+     * Update and save custom css
+     * @param {string} css is text of custom css
+     */
+    async saveCustomCss(css) {
+        const settings = await this.loadSettings();
+        settings.css = css;
+        return this._saveSettings(settings);
+    }
+
     /**
      * Subscribe to settings change event, watched by settings key
      * @param {string} key

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -21,9 +21,16 @@
     max-width: 100%;
     min-width: 100%;
     pointer-events: none;
-    fill: darkorange;
+    fill: lightgrey;
+}
+
+h2 .sanitizer-action-remove-hub 
+{
+	position: absolute;
+	right: 1em;
 }
 
 .sanitizer-action-remove-hub:hover > svg {
     fill: red;
 }
+

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -172,3 +172,7 @@ body {
     margin: 1em 0;
     padding: 1em;
 }
+
+#custom-javascript, #custom-css { height: 6em; width: 100%; }
+
+#save-custom-css, #save-custom-javascript { display: inline-block; }


### PR DESCRIPTION
- close an article
- custom css (to hide unwanted blocks ). I use the following css:

`.promo-block_vacancies, .promo-block_courses, .promo-block_freelansim-tasks, #companies_rating, #effect, #company-links, #profile-company, #fb-like, .pinned-block, .content-list__item_news-block, .promo-block_questions, .promo-block_salary, #effect-sidebar { display: none !important; }`

- custom js
- always visible for rates more than +N

I am not JS dev, so not very good at it. Tried to follow your style, but most probably missed something
Also, don't have any tools - like linters and etc., so not sure if formatting is matching yours