### PR TITLE
Fixed an issue when show/hide icon was shown at the comment thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HabroSanitizer - web extension to sanitize Habr.com from graphomaniac authors
 
+## [06.09.2021] V.2.7.3
+
+* Fixed rare issue when show/hide icon appeared on the comment thread - #27
+
 ## [23.08.2021] V.2.7.2
 
 * Fixed possibility to interact with asterisk behind the hub name

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
     "author": "drag13",
     "name": "HabroSanitizer for Habrahabr",
     "description": "HabroSanitizer hides posts in the feed written by unwanted authors or companies on Habr.com (habrahabr). Free, no ads, no telemetry.",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "permissions": ["storage"],
     "icons": {
         "16": "./asset/i16.png",

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -17,8 +17,8 @@ async function sanitize() {
         companyNew: '.tm-article-snippet__title-link',
         hub: 'a.hub-link',
         hubNew: '.tm-article-snippet__hubs-item-link span:first-child',
-        article: 'article',
-        visibleArticle: `article:not(.${hiddenArticleClassName})`,
+        article: 'article:not(.tm-comment-thread__comment)',
+        visibleArticle: `article:not(.tm-comment-thread__comment):not(.${hiddenArticleClassName})`,
         hiddenArticle: `article.${hiddenArticleClassName}`,
     };
 


### PR DESCRIPTION
Fixed #27, by excluding articles with `.tm-comment-thread__comment` class from sanitizing